### PR TITLE
Additional API endpoints exposed for MemoryBlockCache (BlockCache)

### DIFF
--- a/api.go
+++ b/api.go
@@ -22,8 +22,32 @@ func StartAPIServer() error {
 		c.IndentedJSON(http.StatusOK, gin.H{"length": BlockCache.Length(), "items": BlockCache.Backend})
 	})
 
+	router.GET("/blockcache/exists/:key", func(c *gin.Context) {
+		c.IndentedJSON(http.StatusOK, gin.H{"exists": BlockCache.Exists(c.Param("key"))})
+	})
+
+	router.GET("/blockcache/get/:key", func(c *gin.Context) {
+		if ok, _ := BlockCache.Get(c.Param("key")); !ok {
+			c.IndentedJSON(http.StatusOK, gin.H{"error": c.Param("key") + " not found"})
+		} else {
+			c.IndentedJSON(http.StatusOK, gin.H{"success": ok})
+		}
+	})
+
 	router.GET("/blockcache/length", func(c *gin.Context) {
 		c.IndentedJSON(http.StatusOK, gin.H{"length": BlockCache.Length()})
+	})
+
+	router.GET("/blockcache/remove/:key", func(c *gin.Context) {
+		// Removes from BlockCache only. If the domain has already been queried and placed into MemoryCache, will need to wait until item is expired.
+		BlockCache.Remove(c.Param("key"))
+		c.IndentedJSON(http.StatusOK, gin.H{"success": true})
+	})
+
+	router.GET("/blockcache/set/:key", func(c *gin.Context) {
+		// MemoryBlockCache Set() always returns nil, so ignoring response.
+		_ = BlockCache.Set(c.Param("key"), true)
+		c.IndentedJSON(http.StatusOK, gin.H{"success": true})
 	})
 
 	router.GET("/questioncache", func(c *gin.Context) {

--- a/cache.go
+++ b/cache.go
@@ -168,6 +168,13 @@ func (c *MemoryBlockCache) Get(key string) (bool, error) {
 	return val, nil
 }
 
+// Remove removes an entry from the cache
+func (c *MemoryBlockCache) Remove(key string) {
+	c.mu.Lock()
+	delete(c.Backend, key)
+	c.mu.Unlock()
+}
+
 // Set sets a value in the BlockCache
 func (c *MemoryBlockCache) Set(key string, value bool) error {
 	c.mu.Lock()


### PR DESCRIPTION
New endpoints
* /blockcache/exists/:key
* /blockcache/get/:key
* /blockcache/remove/:key
* /blockcache/set/:key

Along with a Remove method to the MemoryBlockCache struct.

Due to MemoryCache not being accessible from the APIServer any set/remove actions performed on keys that already exist in MemoryCache will require eviction/expiry.