### PR TITLE
Fixed toggle (issue #13): empty string was matching any domain

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -85,7 +85,7 @@ func (h *DNSHandler) do(Net string, w dns.ResponseWriter, req *dns.Msg) {
 	}
 
 	var grimdActive = grimdActivation.query()
-	if strings.Contains(Q.Qname, Config.ToggleName) {
+	if len(Config.ToggleName) >0 && strings.Contains(Q.Qname, Config.ToggleName) {
 		if Config.LogLevel > 0 {
 			log.Printf("Found ToggleName! (%s)\n", Q.Qname)
 		}


### PR DESCRIPTION
The empty string was matching any domain thus toggling grimd on and off. This fixes it.
