### PR TITLE
Another fixed with TCP connections crashing the server

### DIFF
--- a/api.go
+++ b/api.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 
 	"gopkg.in/gin-contrib/cors.v1"
-	"gopkg.in/gin-gonic/gin.v1"
+	"github.com/gin-gonic/gin"
 )
 
 // StartAPIServer launches the API server

--- a/handler.go
+++ b/handler.go
@@ -255,7 +255,7 @@ func (h *DNSHandler) DoUDP(w dns.ResponseWriter, req *dns.Msg) {
 
 func (h *DNSHandler) HandleFailed(w dns.ResponseWriter, message *dns.Msg) {
 	m := new(dns.Msg)
-	m.SetRcode(message, RcodeServerFailure)
+	m.SetRcode(message, dns.RcodeServerFailure)
 	h.WriteReplyMsg(w, m)
 }
 

--- a/handler.go
+++ b/handler.go
@@ -201,7 +201,7 @@ func (h *DNSHandler) do(Net string, w dns.ResponseWriter, req *dns.Msg) {
 
 	if err != nil {
 		log.Printf("resolve query error %s\n", err)
-		dns.HandleFailed(w, req)
+		h.HandleFailed(w, req)
 
 		// cache the failure, too!
 		if err = h.negCache.Set(key, nil, false); err != nil {
@@ -214,7 +214,7 @@ func (h *DNSHandler) do(Net string, w dns.ResponseWriter, req *dns.Msg) {
 		mesg, err = h.resolver.Lookup("tcp", req)
 		if err != nil {
 			log.Printf("resolve tcp query error %s\n", err)
-			dns.HandleFailed(w, req)
+			h.HandleFailed(w, req)
 
 			// cache the failure, too!
 			if err = h.negCache.Set(key, nil, false); err != nil {
@@ -251,6 +251,12 @@ func (h *DNSHandler) DoTCP(w dns.ResponseWriter, req *dns.Msg) {
 // DoUDP begins a udp query
 func (h *DNSHandler) DoUDP(w dns.ResponseWriter, req *dns.Msg) {
 	go h.do("udp", w, req)
+}
+
+func (h *DNSHandler) HandleFailed(w dns.ResponseWriter, message *dns.Msg) {
+	m := new(dns.Msg)
+	m.SetRcode(message, RcodeServerFailure)
+	h.WriteReplyMsg(w, m)
 }
 
 func (h *DNSHandler) WriteReplyMsg(w dns.ResponseWriter, message *dns.Msg) {

--- a/handler.go
+++ b/handler.go
@@ -115,7 +115,7 @@ func (h *DNSHandler) do(Net string, w dns.ResponseWriter, req *dns.Msg) {
 				if Config.LogLevel > 1 {
 					log.Printf("%s hit negative cache\n", Q.String())
 				}
-				dns.HandleFailed(w, req)
+				h.HandleFailed(w, req)
 				return
 			}
 		} else {


### PR DESCRIPTION
This situation happens when a TCP connection comes in and is later interrupted causing a panic call in the DNS library. However, this time the HandleFailed function was bypassing my last fix.