### PR TITLE
Make the lists update wait for the DNS servers to actually start

### DIFF
--- a/server.go
+++ b/server.go
@@ -15,7 +15,7 @@ type Server struct {
 }
 
 // Run starts the server
-func (s *Server) Run() {
+func (s *Server) Run(update_lists chan bool) {
 	Handler := NewHandler()
 
 	tcpHandler := dns.NewServeMux()
@@ -39,6 +39,8 @@ func (s *Server) Run() {
 
 	go s.start(udpServer)
 	go s.start(tcpServer)
+
+	update_lists <- true
 }
 
 func (s *Server) start(ds *dns.Server) {


### PR DESCRIPTION
Make the list update start when the DNS servers have started for real instead of just waiting one second.
panic()s if the DNS does not start within 10 seconds.