### PR TITLE
Proper TTL support for DNS response

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -113,9 +113,9 @@ func (c *MemoryCache) Get(key string) (*dns.Msg, bool, error) {
 		return nil, false, KeyNotFound{key}
 	}
 
-	if mesg.Expire.Before(time.Now()) {
+	if mesg.Expire.Before(WallClock.Now()) {
 		if Config.LogLevel > 1 {
-			log.Printf("Cache: Key expired %s @%d/%d\n", key, mesg.Expire, time.Now())
+			log.Printf("Cache: Key expired %s @%d/%d\n", key, mesg.Expire, WallClock.Now())
 		}
 		c.Remove(key)
 		return nil, false, KeyExpired{key}
@@ -132,7 +132,7 @@ func (c *MemoryCache) Set(key string, msg *dns.Msg, ttl uint32, blocked bool) er
 		return CacheIsFull{}
 	}
 
-	expire := time.Now().Add(time.Duration(ttl) * time.Second)
+	expire := WallClock.Now().Add(time.Duration(ttl) * time.Second)
 	mesg := Mesg{msg, blocked, expire}
 	c.mu.Lock()
 	c.Backend[key] = mesg

--- a/cache.go
+++ b/cache.go
@@ -113,7 +113,9 @@ func (c *MemoryCache) Get(key string) (*dns.Msg, bool, error) {
 		return nil, false, KeyNotFound{key}
 	}
 
-	now := WallClock.Now()
+	//Truncate time to the second, so that subsecond queries won't keep moving
+	//forward the last update time without touching the TTL
+	now := WallClock.Now().Truncate(time.Second)
 	elapsed := uint32(now.Sub(mesg.LastUpdateTime).Seconds())
 	mesg.LastUpdateTime = now
 
@@ -139,7 +141,7 @@ func (c *MemoryCache) Set(key string, msg *dns.Msg, blocked bool) error {
 		return CacheIsFull{}
 	}
 
-	mesg := Mesg{msg, blocked, WallClock.Now()}
+	mesg := Mesg{msg, blocked, WallClock.Now().Truncate(time.Second)}
 	c.mu.Lock()
 	c.Backend[key] = &mesg
 	c.mu.Unlock()

--- a/config.go
+++ b/config.go
@@ -30,7 +30,7 @@ type config struct {
 	Nameservers       []string
 	Interval          int
 	Timeout           int
-	Expire            int
+	Expire            uint
 	Maxcount          int
 	QuestionCacheCap  int
 	TTL               uint32

--- a/config.go
+++ b/config.go
@@ -30,7 +30,7 @@ type config struct {
 	Nameservers       []string
 	Interval          int
 	Timeout           int
-	Expire            uint
+	Expire            uint32
 	Maxcount          int
 	QuestionCacheCap  int
 	TTL               uint32

--- a/config.go
+++ b/config.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/BurntSushi/toml"
+	"github.com/jonboulle/clockwork"
 )
 
 // BuildVersion returns the build version of grimd, this should be incremented every new release
@@ -112,6 +113,9 @@ togglename = ""
 # having been turned off.
 reactivationdelay = 300
 `
+
+// WallClock is the wall clock
+var WallClock = clockwork.NewRealClock()
 
 // Config is the global configuration
 var Config config

--- a/handler.go
+++ b/handler.go
@@ -54,11 +54,11 @@ func NewHandler() *DNSHandler {
 	resolver = &Resolver{clientConfig}
 
 	cache = &MemoryCache{
-		Backend:  make(map[string]Mesg, Config.Maxcount),
+		Backend:  make(map[string]*Mesg, Config.Maxcount),
 		Maxcount: Config.Maxcount,
 	}
 	negCache = &MemoryCache{
-		Backend: make(map[string]Mesg),
+		Backend: make(map[string]*Mesg),
 		// Expire:   time.Duration(Config.Expire) * time.Second / 2,
 		Maxcount: Config.Maxcount,
 	}
@@ -180,7 +180,7 @@ func (h *DNSHandler) do(Net string, w dns.ResponseWriter, req *dns.Msg) {
 			go QuestionCache.Add(NewEntry)
 
 			// cache the block; we don't know the true TTL for blocked entries: we just enforce our config
-			err := h.cache.Set(key, m, Config.Expire, true)
+			err := h.cache.Set(key, m, true)
 			if err != nil {
 				log.Printf("Set %s block cache failed: %s\n", Q.String(), err.Error())
 			}
@@ -203,7 +203,7 @@ func (h *DNSHandler) do(Net string, w dns.ResponseWriter, req *dns.Msg) {
 		h.HandleFailed(w, req)
 
 		// cache the failure, too!
-		if err = h.negCache.Set(key, nil, Config.Expire, false); err != nil {
+		if err = h.negCache.Set(key, nil, false); err != nil {
 			log.Printf("set %s negative cache failed: %v\n", Q.String(), err)
 		}
 		return
@@ -216,7 +216,7 @@ func (h *DNSHandler) do(Net string, w dns.ResponseWriter, req *dns.Msg) {
 			h.HandleFailed(w, req)
 
 			// cache the failure, too!
-			if err = h.negCache.Set(key, nil, Config.Expire, false); err != nil {
+			if err = h.negCache.Set(key, nil, false); err != nil {
 				log.Printf("set %s negative cache failed: %v\n", Q.String(), err)
 			}
 			return
@@ -247,7 +247,7 @@ func (h *DNSHandler) do(Net string, w dns.ResponseWriter, req *dns.Msg) {
 				log.Printf("%s is blacklisted and grimd not active: not caching\n", Q.String())
 			}
 		} else {
-			err = h.cache.Set(key, mesg, ttl, false)
+			err = h.cache.Set(key, mesg, false)
 			if err != nil {
 				log.Printf("set %s cache failed: %s\n", Q.String(), err.Error())
 			}


### PR DESCRIPTION
I've changed the response cache to use the actual responses TTL for expiration.
The Get() operation also updates the TTL field in the answer so that it is consistent with the expected expiration.