### PR TITLE
Fixing questioncache to not reutrn nil on clear

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -275,7 +275,7 @@ func (c *MemoryQuestionCache) Add(q QuestionCacheEntry) {
 // Clear clears the contents of the cache
 func (c *MemoryQuestionCache) Clear() {
 	c.mu.Lock()
-	c.Backend = nil
+	c.Backend = make([]QuestionCacheEntry, 0, 0)
 	c.mu.Unlock()
 }
 


### PR DESCRIPTION
When using grimer and reaper together, a fun race condition can be triggered when clearing the question cache.

Immediately after the questioncache is cleared, the response gives the following:

```json
{
	"items": null,
	"length": 0,
}
```

Which would be fine, but reaper uses length on the JSON.parsed `items` of that result.

Since the likelihood of a new DNS question is low between the time clear is clicked and a refresh occurs, reaper often panics trying to get `length` of `null`.

Steps to reproduce:

1. Start server
2. curl localhost:8080/questioncache (note items is `[]`)
3. curl localhost:8080/questioncache/clear
4. curl localhost:8080/questioncache (note items is `null`)

Hopefully this patch finds you well, and happy #hacktoberfest!