### PR TITLE
Perform cache deletion within the mutex lock, to avoid races

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -109,6 +109,11 @@ func (c *MemoryCache) Get(key string) (*dns.Msg, bool, error) {
 	expired := false
 	c.mu.RLock()
 	mesg, ok := c.Backend[key]
+	if ok && mesg.Msg == nil {
+		ok = false;
+		log.Printf("Cache: key %s returned nil entry");
+		c.removeNoLock(key)
+	}
 	if ok{
 		elapsed := uint32(now.Sub(mesg.LastUpdateTime).Seconds())
 		for _, answer := range mesg.Msg.Answer {

--- a/cache.go
+++ b/cache.go
@@ -102,8 +102,26 @@ type MemoryQuestionCache struct {
 func (c *MemoryCache) Get(key string) (*dns.Msg, bool, error) {
 	key = strings.ToLower(key)
 
+	//Truncate time to the second, so that subsecond queries won't keep moving
+	//forward the last update time without touching the TTL
+	now := WallClock.Now().Truncate(time.Second)
+
+	expired := false
 	c.mu.RLock()
 	mesg, ok := c.Backend[key]
+	if ok{
+		elapsed := uint32(now.Sub(mesg.LastUpdateTime).Seconds())
+		for _, answer := range mesg.Msg.Answer {
+			if elapsed > answer.Header().Ttl {
+				if Config.LogLevel > 1 {
+					log.Printf("Cache: Key expired %s", key)
+				}
+				c.Remove(key)
+				expired = true
+			}
+			answer.Header().Ttl -= elapsed
+		}
+	}
 	c.mu.RUnlock()
 
 	if !ok {
@@ -113,22 +131,12 @@ func (c *MemoryCache) Get(key string) (*dns.Msg, bool, error) {
 		return nil, false, KeyNotFound{key}
 	}
 
-	//Truncate time to the second, so that subsecond queries won't keep moving
-	//forward the last update time without touching the TTL
-	now := WallClock.Now().Truncate(time.Second)
-	elapsed := uint32(now.Sub(mesg.LastUpdateTime).Seconds())
+	if expired {
+		return nil, false, KeyExpired{key}
+	}
+
 	mesg.LastUpdateTime = now
 
-	for _, answer := range mesg.Msg.Answer {
-		if elapsed > answer.Header().Ttl {
-			if Config.LogLevel > 1 {
-				log.Printf("Cache: Key expired %s", key)
-			}
-			c.Remove(key)
-			return nil, false, KeyExpired{key}
-		}
-		answer.Header().Ttl -= elapsed
-	}
 
 	return mesg.Msg, mesg.Blocked, nil
 }

--- a/cache.go
+++ b/cache.go
@@ -110,11 +110,11 @@ func (c *MemoryCache) Get(key string) (*dns.Msg, bool, error) {
 	c.mu.RLock()
 	mesg, ok := c.Backend[key]
 	if ok && mesg.Msg == nil {
-		ok = false;
-		log.Printf("Cache: key %s returned nil entry", key);
+		ok = false
+		log.Printf("Cache: key %s returned nil entry", key)
 		c.removeNoLock(key)
 	}
-	if ok{
+	if ok {
 		elapsed := uint32(now.Sub(mesg.LastUpdateTime).Seconds())
 		for _, answer := range mesg.Msg.Answer {
 			if elapsed > answer.Header().Ttl {
@@ -142,7 +142,6 @@ func (c *MemoryCache) Get(key string) (*dns.Msg, bool, error) {
 
 	mesg.LastUpdateTime = now
 
-
 	return mesg.Msg, mesg.Blocked, nil
 }
 
@@ -153,13 +152,13 @@ func (c *MemoryCache) Set(key string, msg *dns.Msg, blocked bool) error {
 	if c.Full() && !c.Exists(key) {
 		return CacheIsFull{}
 	}
-    if msg == nil {
-		log.Printf("Trying to set an empty value for key %s", key);
+	if msg == nil {
+		log.Printf("Trying to set an empty value for key %s", key)
 		if Config.LogLevel > 1 {
 			panic("Empty cache value")
 		}
 		return nil
-    }
+	}
 	mesg := Mesg{msg, blocked, WallClock.Now().Truncate(time.Second)}
 	c.mu.Lock()
 	c.Backend[key] = &mesg

--- a/cache.go
+++ b/cache.go
@@ -116,7 +116,7 @@ func (c *MemoryCache) Get(key string) (*dns.Msg, bool, error) {
 				if Config.LogLevel > 1 {
 					log.Printf("Cache: Key expired %s", key)
 				}
-				c.Remove(key)
+				c.removeNoLock(key)
 				expired = true
 			}
 			answer.Header().Ttl -= elapsed
@@ -158,11 +158,15 @@ func (c *MemoryCache) Set(key string, msg *dns.Msg, blocked bool) error {
 }
 
 // Remove removes an entry from the cache
-func (c *MemoryCache) Remove(key string) {
+func (c *MemoryCache) removeNoLock(key string) {
 	key = strings.ToLower(key)
-
-	c.mu.Lock()
 	delete(c.Backend, key)
+}
+
+// Remove removes an entry from the cache
+func (c *MemoryCache) Remove(key string) {
+	c.mu.Lock()
+	c.removeNoLock(key)
 	c.mu.Unlock()
 }
 

--- a/cache.go
+++ b/cache.go
@@ -111,7 +111,7 @@ func (c *MemoryCache) Get(key string) (*dns.Msg, bool, error) {
 	mesg, ok := c.Backend[key]
 	if ok && mesg.Msg == nil {
 		ok = false;
-		log.Printf("Cache: key %s returned nil entry");
+		log.Printf("Cache: key %s returned nil entry", key);
 		c.removeNoLock(key)
 	}
 	if ok{
@@ -153,7 +153,13 @@ func (c *MemoryCache) Set(key string, msg *dns.Msg, blocked bool) error {
 	if c.Full() && !c.Exists(key) {
 		return CacheIsFull{}
 	}
-
+    if msg == nil {
+		log.Printf("Trying to set an empty value for key %s", key);
+		if Config.LogLevel > 1 {
+			panic("Empty cache value")
+		}
+		return nil
+    }
 	mesg := Mesg{msg, blocked, WallClock.Now().Truncate(time.Second)}
 	c.mu.Lock()
 	c.Backend[key] = &mesg

--- a/cache.go
+++ b/cache.go
@@ -153,11 +153,7 @@ func (c *MemoryCache) Set(key string, msg *dns.Msg, blocked bool) error {
 		return CacheIsFull{}
 	}
 	if msg == nil {
-		log.Printf("Trying to set an empty value for key %s", key)
-		if Config.LogLevel > 1 {
-			panic("Empty cache value")
-		}
-		return nil
+		log.Printf("Setting an empty value for key %s", key)
 	}
 	mesg := Mesg{msg, blocked, WallClock.Now().Truncate(time.Second)}
 	c.mu.Lock()
@@ -211,6 +207,9 @@ func KeyGen(q Question) string {
 	h.Write([]byte(q.String()))
 	x := h.Sum(nil)
 	key := fmt.Sprintf("%x", x)
+	if Config.LogLevel > 1 {
+		log.Printf("KeyGen: %s %s", q.String(), key)
+	}
 	return key
 }
 


### PR DESCRIPTION
It was possible that the cached element was invalidated between the retrieval from the cache and its usage, leading to dereferencing a nil pointer