### PR TITLE
Add an endpoint to trigger blocklist updates via the API

### DIFF
--- a/activation.go
+++ b/activation.go
@@ -25,7 +25,7 @@ func (a *ActivationHandler) loop(quit <-chan bool) {
 	a.toggle_channel = make(chan ToggleData)
 	a.set_channel = make(chan bool)
 
-    ticker := time.Tick(1 * time.Second)
+	ticker := time.Tick(1 * time.Second)
 
 	var nextToggleTime = time.Now()
 
@@ -59,7 +59,7 @@ forever:
 			grimdActive = v
 			reactivate_pending = false
 			a.set_channel <- grimdActive
-        case <- ticker:
+		case <-ticker:
 			now := time.Now()
 			if reactivate_pending && now.After(reactivate) {
 				log.Print("Reactivating grimd (timer)\n")

--- a/api.go
+++ b/api.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"strconv"
 
-	"gopkg.in/gin-contrib/cors.v1"
 	"github.com/gin-gonic/gin"
+	"gopkg.in/gin-contrib/cors.v1"
 )
 
 // StartAPIServer launches the API server
@@ -119,6 +119,11 @@ func StartAPIServer() error {
 				c.JSON(http.StatusBadRequest, gin.H{"error": "Illegal value for 'state'"})
 			}
 		}
+	})
+
+	router.POST("/blocklist/update", func(c *gin.Context) {
+		PerformUpdate(true)
+		c.AbortWithStatus(http.StatusOK)
 	})
 
 	if err := router.Run(Config.API); err != nil {

--- a/main.go
+++ b/main.go
@@ -53,14 +53,7 @@ func main() {
 		if !run {
 			panic("The DNS server did not start in 10 seconds")
 		}
-		if _, err := os.Stat("lists"); os.IsNotExist(err) || forceUpdate {
-			if err := Update(); err != nil {
-				log.Fatal(err)
-			}
-		}
-		if err := UpdateBlockCache(); err != nil {
-			log.Fatal(err)
-		}
+		PerformUpdate(forceUpdate)
 	}()
 
 	grimdActive = true


### PR DESCRIPTION
With this I no longer need to restart grimd to download new blocklists and update them.
The update happens by swapping out the old and new blocklists so there is no interruption. Cached entries will keep to be served until the TTL expires.
