### PR TITLE
Add Syslog support

### DIFF
--- a/activation.go
+++ b/activation.go
@@ -4,20 +4,20 @@ import (
 	"time"
 )
 
-// ToggleData type
+// ToggleData type holds the data for the activation toggle channel
 type ToggleData struct {
 	Mode uint
 	Data uint
 }
 
-// ActivationHandler type
+// ActivationHandler type holds the machinery for toggling grimd on and off
 type ActivationHandler struct {
 	queryChannel  chan bool
 	toggleChannel chan ToggleData
 	setChannel    chan bool
 }
 
-func (a *ActivationHandler) loop(quit <-chan bool, reactivationDelay uint) {
+func (a *ActivationHandler) loop(quit <-chan bool) {
 	var reactivate time.Time
 	var reactivatePending bool
 
@@ -47,7 +47,7 @@ forever:
 					grimdActive = false
 				}
 				nextToggleTime = time.Now().Add(time.Duration(10) * time.Second)
-				if !grimdActive && reactivationDelay > 0 {
+				if !grimdActive && Config.ReactivationDelay > 0 {
 					reactivate = time.Now().Add(time.Duration(v.Data) * time.Second)
 					reactivatePending = true
 				} else {
@@ -83,10 +83,10 @@ func (a ActivationHandler) set(v bool) bool {
 }
 
 // Toggle activation state on or off
-func (a ActivationHandler) toggle(reactivationDelay uint) bool {
+func (a ActivationHandler) toggle() bool {
 	data := ToggleData{
 		Mode: 1,
-		Data: reactivationDelay,
+		Data: Config.ReactivationDelay,
 	}
 	a.toggleChannel <- data
 	return <-a.queryChannel

--- a/cache.go
+++ b/cache.go
@@ -73,11 +73,14 @@ type MemoryCache struct {
 }
 
 const (
-	BlockCacheEntryString = iota
-	BlockCacheEntryRegexp
+	// BlockCacheEntryRegexp marks the regexp based BlockCache entries
+	BlockCacheEntryRegexp = iota
+	// BlockCacheEntryGlob marks the glob based BlockCache entries
 	BlockCacheEntryGlob
 )
 
+// BlockCacheSpecial holds the extra data of a BlockCache entry
+// used to perform glob or regexp matching.
 type BlockCacheSpecial struct {
 	Data string
 	Type int
@@ -106,7 +109,7 @@ func (c *MemoryCache) Get(key string) (*dns.Msg, bool, error) {
 	now := WallClock.Now().Truncate(time.Second)
 
 	expired := false
-	c.mu.Lock()
+	c.mu.RLock()
 	mesg, ok := c.Backend[key]
 	if ok && mesg.Msg == nil {
 		ok = false
@@ -124,7 +127,7 @@ func (c *MemoryCache) Get(key string) (*dns.Msg, bool, error) {
 			answer.Header().Ttl -= elapsed
 		}
 	}
-	c.mu.Unlock()
+	c.mu.RUnlock()
 
 	if !ok {
 		logger.Debugf("Cache: Cannot find key %s\n", key)

--- a/cache_test.go
+++ b/cache_test.go
@@ -260,7 +260,7 @@ func TestExpirationRace(t *testing.T) {
 	m := new(dns.Msg)
 	m.SetQuestion(dns.Fqdn(testDomain), dns.TypeA)
 
-	nullroute := net.ParseIP(Config.Nullroute)
+	nullroute := net.ParseIP("0.0.0.0")
 	a := &dns.A{
 		Hdr: dns.RR_Header{
 			Name:   testDomain,

--- a/config.go
+++ b/config.go
@@ -16,14 +16,14 @@ import (
 var BuildVersion = "1.0.5"
 
 // ConfigVersion returns the version of grimd, this should be incremented every time the config changes so grimd presents a warning
-var ConfigVersion = "1.0.2"
+var ConfigVersion = "1.0.3"
 
 // Config holds the configuration parameters
 type Config struct {
 	Version           string
 	Sources           []string
 	SourceDirs        []string
-	Log               string
+	LogConfig         string
 	LogLevel          int
 	Bind              string
 	API               string
@@ -63,7 +63,7 @@ sourcedirs = [
 ]
 
 # location of the log file
-log = "grimd.log"
+logconfig = "stderr,file:grimd.log"
 
 # what kind of information should be logged, 0 = errors and important operations, 1 = dns queries, 2 = debug
 loglevel = 0

--- a/handler.go
+++ b/handler.go
@@ -36,21 +36,13 @@ func (q *Question) String() string {
 
 // DNSHandler type
 type DNSHandler struct {
-	requestChannel chan DNSOperationData
-	resolver       *Resolver
-	cache          Cache
-	negCache       Cache
-}
-
-// DNSOperationData type
-type DNSOperationData struct {
-	Net string
-	w   dns.ResponseWriter
-	req *dns.Msg
+	resolver *Resolver
+	cache    Cache
+	negCache Cache
 }
 
 // NewHandler returns a new DNSHandler
-func NewHandler(config *Config, blockCache *MemoryBlockCache, questionCache *MemoryQuestionCache) *DNSHandler {
+func NewHandler() *DNSHandler {
 	var (
 		clientConfig *dns.ClientConfig
 		resolver     *Resolver
@@ -61,219 +53,203 @@ func NewHandler(config *Config, blockCache *MemoryBlockCache, questionCache *Mem
 	resolver = &Resolver{clientConfig}
 
 	cache = &MemoryCache{
-		Backend:  make(map[string]*Mesg, config.Maxcount),
-		Maxcount: config.Maxcount,
+		Backend:  make(map[string]*Mesg, Config.Maxcount),
+		Maxcount: Config.Maxcount,
 	}
 	negCache = &MemoryCache{
-		Backend:  make(map[string]*Mesg),
-		Maxcount: config.Maxcount,
+		Backend: make(map[string]*Mesg),
+		// Expire:   time.Duration(Config.Expire) * time.Second / 2,
+		Maxcount: Config.Maxcount,
 	}
 
-	handler := &DNSHandler{
-		requestChannel: make(chan DNSOperationData),
-		resolver:       resolver,
-		cache:          cache,
-		negCache:       negCache,
-	}
-
-	go handler.do(config, blockCache, questionCache)
-
-	return handler
+	return &DNSHandler{resolver, cache, negCache}
 }
 
-func (h *DNSHandler) do(config *Config, blockCache *MemoryBlockCache, questionCache *MemoryQuestionCache) {
-	for {
-		data, ok := <-h.requestChannel
-		if !ok {
-			break
+func (h *DNSHandler) do(Net string, w dns.ResponseWriter, req *dns.Msg) {
+	defer w.Close()
+	q := req.Question[0]
+	Q := Question{UnFqdn(q.Name), dns.TypeToString[q.Qtype], dns.ClassToString[q.Qclass]}
+
+	var remote net.IP
+	if Net == "tcp" {
+		remote = w.RemoteAddr().(*net.TCPAddr).IP
+	} else {
+		remote = w.RemoteAddr().(*net.UDPAddr).IP
+	}
+
+	logger.Infof("%s lookup　%s\n", remote, Q.String())
+
+	var grimdActive = grimdActivation.query()
+	if len(Config.ToggleName) > 0 && strings.Contains(Q.Qname, Config.ToggleName) {
+		logger.Noticef("Found ToggleName! (%s)\n", Q.Qname)
+		grimdActive = grimdActivation.toggle()
+
+		if grimdActive {
+			logger.Notice("Grimd Activated")
+		} else {
+			logger.Notice("Grimd Deactivated")
 		}
-		func(Net string, w dns.ResponseWriter, req *dns.Msg) {
-			defer w.Close()
-			q := req.Question[0]
-			Q := Question{UnFqdn(q.Name), dns.TypeToString[q.Qtype], dns.ClassToString[q.Qclass]}
+	}
 
-			var remote net.IP
-			if Net == "tcp" {
-				remote = w.RemoteAddr().(*net.TCPAddr).IP
+	IPQuery := h.isIPQuery(q)
+
+	// Only query cache when qtype == 'A'|'AAAA' , qclass == 'IN'
+	key := KeyGen(Q)
+	if IPQuery > 0 {
+		mesg, blocked, err := h.cache.Get(key)
+		if err != nil {
+			if mesg, blocked, err = h.negCache.Get(key); err != nil {
+				logger.Debugf("%s didn't hit cache\n", Q.String())
 			} else {
-				remote = w.RemoteAddr().(*net.UDPAddr).IP
-			}
-
-			logger.Infof("%s lookup　%s\n", remote, Q.String())
-
-			var grimdActive = grimdActivation.query()
-			if len(config.ToggleName) > 0 && strings.Contains(Q.Qname, config.ToggleName) {
-				logger.Noticef("Found ToggleName! (%s)\n", Q.Qname)
-				grimdActive = grimdActivation.toggle(config.ReactivationDelay)
-
-				if grimdActive {
-					logger.Notice("Grimd Activated")
-				} else {
-					logger.Notice("Grimd Deactivated")
-				}
-			}
-
-			IPQuery := h.isIPQuery(q)
-
-			// Only query cache when qtype == 'A'|'AAAA' , qclass == 'IN'
-			key := KeyGen(Q)
-			if IPQuery > 0 {
-				mesg, blocked, err := h.cache.Get(key)
-				if err != nil {
-					if mesg, blocked, err = h.negCache.Get(key); err != nil {
-						logger.Debugf("%s didn't hit cache\n", Q.String())
-					} else {
-						logger.Debugf("%s hit negative cache\n", Q.String())
-						h.HandleFailed(w, req)
-						return
-					}
-				} else {
-					if blocked && !grimdActive {
-						logger.Debugf("%s hit cache and was blocked: forwarding request\n", Q.String())
-					} else {
-						logger.Debugf("%s hit cache\n", Q.String())
-
-						// we need this copy against concurrent modification of Id
-						msg := *mesg
-						msg.Id = req.Id
-						h.WriteReplyMsg(w, &msg)
-						return
-					}
-				}
-			}
-			// Check blocklist
-			var blacklisted = false
-
-			if IPQuery > 0 {
-				blacklisted = blockCache.Exists(Q.Qname)
-
-				if grimdActive && blacklisted {
-					m := new(dns.Msg)
-					m.SetReply(req)
-
-					nullroute := net.ParseIP(config.Nullroute)
-					nullroutev6 := net.ParseIP(config.Nullroutev6)
-
-					switch IPQuery {
-					case _IP4Query:
-						rrHeader := dns.RR_Header{
-							Name:   q.Name,
-							Rrtype: dns.TypeA,
-							Class:  dns.ClassINET,
-							Ttl:    config.TTL,
-						}
-						a := &dns.A{Hdr: rrHeader, A: nullroute}
-						m.Answer = append(m.Answer, a)
-					case _IP6Query:
-						rrHeader := dns.RR_Header{
-							Name:   q.Name,
-							Rrtype: dns.TypeAAAA,
-							Class:  dns.ClassINET,
-							Ttl:    config.TTL,
-						}
-						a := &dns.AAAA{Hdr: rrHeader, AAAA: nullroutev6}
-						m.Answer = append(m.Answer, a)
-					}
-
-					h.WriteReplyMsg(w, m)
-
-					logger.Noticef("%s found in blocklist\n", Q.Qname)
-
-					// log query
-					NewEntry := QuestionCacheEntry{Date: time.Now().Unix(), Remote: remote.String(), Query: Q, Blocked: true}
-					go questionCache.Add(NewEntry)
-
-					// cache the block; we don't know the true TTL for blocked entries: we just enforce our config
-					err := h.cache.Set(key, m, true)
-					if err != nil {
-						logger.Errorf("Set %s block cache failed: %s\n", Q.String(), err.Error())
-					}
-
-					return
-				}
-				logger.Debugf("%s not found in blocklist\n", Q.Qname)
-			}
-
-			// log query
-			NewEntry := QuestionCacheEntry{Date: time.Now().Unix(), Remote: remote.String(), Query: Q, Blocked: false}
-			go questionCache.Add(NewEntry)
-
-			mesg, err := h.resolver.Lookup(Net, req, config.Timeout, config.Interval, config.Nameservers)
-
-			if err != nil {
-				logger.Errorf("resolve query error %s\n", err)
+				logger.Debugf("%s hit negative cache\n", Q.String())
 				h.HandleFailed(w, req)
-
-				// cache the failure, too!
-				if err = h.negCache.Set(key, nil, false); err != nil {
-					logger.Errorf("set %s negative cache failed: %v\n", Q.String(), err)
-				}
 				return
 			}
+		} else {
+			if blocked && !grimdActive {
+				logger.Debugf("%s hit cache and was blocked: forwarding request\n", Q.String())
+			} else {
+				logger.Debugf("%s hit cache\n", Q.String())
 
-			if mesg.Truncated && Net == "udp" {
-				mesg, err = h.resolver.Lookup("tcp", req, config.Timeout, config.Interval, config.Nameservers)
-				if err != nil {
-					logger.Errorf("resolve tcp query error %s\n", err)
-					h.HandleFailed(w, req)
+				// we need this copy against concurrent modification of Id
+				msg := *mesg
+				msg.Id = req.Id
+				h.WriteReplyMsg(w, &msg)
+				return
+			}
+		}
+	}
+	// Check blocklist
+	var blacklisted = false
 
-					// cache the failure, too!
-					if err = h.negCache.Set(key, nil, false); err != nil {
-						logger.Errorf("set %s negative cache failed: %v\n", Q.String(), err)
-					}
-					return
+	if IPQuery > 0 {
+		blacklisted = BlockCache.Exists(Q.Qname)
+
+		if grimdActive && blacklisted {
+			m := new(dns.Msg)
+			m.SetReply(req)
+
+			nullroute := net.ParseIP(Config.Nullroute)
+			nullroutev6 := net.ParseIP(Config.Nullroutev6)
+
+			switch IPQuery {
+			case _IP4Query:
+				rrHeader := dns.RR_Header{
+					Name:   q.Name,
+					Rrtype: dns.TypeA,
+					Class:  dns.ClassINET,
+					Ttl:    Config.TTL,
 				}
+				a := &dns.A{Hdr: rrHeader, A: nullroute}
+				m.Answer = append(m.Answer, a)
+			case _IP6Query:
+				rrHeader := dns.RR_Header{
+					Name:   q.Name,
+					Rrtype: dns.TypeAAAA,
+					Class:  dns.ClassINET,
+					Ttl:    Config.TTL,
+				}
+				a := &dns.AAAA{Hdr: rrHeader, AAAA: nullroutev6}
+				m.Answer = append(m.Answer, a)
 			}
 
-			//find the smallest ttl
-			ttl := config.Expire
-			var candidateTTL uint32
+			h.WriteReplyMsg(w, m)
 
-			for index, answer := range mesg.Answer {
-				logger.Debugf("Answer %d - %s\n", index, answer.String())
+			logger.Noticef("%s found in blocklist\n", Q.Qname)
 
-				candidateTTL = answer.Header().Ttl
+			// log query
+			NewEntry := QuestionCacheEntry{Date: time.Now().Unix(), Remote: remote.String(), Query: Q, Blocked: true}
+			go QuestionCache.Add(NewEntry)
 
-				if candidateTTL > 0 && candidateTTL < ttl {
-					ttl = candidateTTL
-				}
+			// cache the block; we don't know the true TTL for blocked entries: we just enforce our config
+			err := h.cache.Set(key, m, true)
+			if err != nil {
+				logger.Errorf("Set %s block cache failed: %s\n", Q.String(), err.Error())
 			}
 
-			h.WriteReplyMsg(w, mesg)
+			return
+		}
+		logger.Debugf("%s not found in blocklist\n", Q.Qname)
+	}
 
-			if IPQuery > 0 && len(mesg.Answer) > 0 {
-				if !grimdActive && blacklisted {
-					logger.Debugf("%s is blacklisted and grimd not active: not caching\n", Q.String())
-				} else {
-					err = h.cache.Set(key, mesg, false)
-					if err != nil {
-						logger.Errorf("set %s cache failed: %s\n", Q.String(), err.Error())
-					}
-					logger.Debugf("insert %s into cache with ttl %d\n", Q.String(), ttl)
-				}
+	// log query
+	NewEntry := QuestionCacheEntry{Date: time.Now().Unix(), Remote: remote.String(), Query: Q, Blocked: false}
+	go QuestionCache.Add(NewEntry)
+
+	mesg, err := h.resolver.Lookup(Net, req)
+
+	if err != nil {
+		logger.Errorf("resolve query error %s\n", err)
+		h.HandleFailed(w, req)
+
+		// cache the failure, too!
+		if err = h.negCache.Set(key, nil, false); err != nil {
+			logger.Errorf("set %s negative cache failed: %v\n", Q.String(), err)
+		}
+		return
+	}
+
+	if mesg.Truncated && Net == "udp" {
+		mesg, err = h.resolver.Lookup("tcp", req)
+		if err != nil {
+			logger.Errorf("resolve tcp query error %s\n", err)
+			h.HandleFailed(w, req)
+
+			// cache the failure, too!
+			if err = h.negCache.Set(key, nil, false); err != nil {
+				logger.Errorf("set %s negative cache failed: %v\n", Q.String(), err)
 			}
-		}(data.Net, data.w, data.req)
+			return
+		}
+	}
+
+	//find the smallest ttl
+	ttl := Config.Expire
+	var candidateTTL uint32
+
+	for index, answer := range mesg.Answer {
+		logger.Debugf("Answer %d - %s\n", index, answer.String())
+
+		candidateTTL = answer.Header().Ttl
+
+		if candidateTTL > 0 && candidateTTL < ttl {
+			ttl = candidateTTL
+		}
+	}
+
+	h.WriteReplyMsg(w, mesg)
+
+	if IPQuery > 0 && len(mesg.Answer) > 0 {
+		if !grimdActive && blacklisted {
+			logger.Debugf("%s is blacklisted and grimd not active: not caching\n", Q.String())
+		} else {
+			err = h.cache.Set(key, mesg, false)
+			if err != nil {
+				logger.Errorf("set %s cache failed: %s\n", Q.String(), err.Error())
+			}
+			logger.Debugf("insert %s into cache with ttl %d\n", Q.String(), ttl)
+		}
 	}
 }
 
 // DoTCP begins a tcp query
 func (h *DNSHandler) DoTCP(w dns.ResponseWriter, req *dns.Msg) {
-	h.requestChannel <- DNSOperationData{"tcp", w, req}
+	go h.do("tcp", w, req)
 }
 
 // DoUDP begins a udp query
 func (h *DNSHandler) DoUDP(w dns.ResponseWriter, req *dns.Msg) {
-	h.requestChannel <- DNSOperationData{"udp", w, req}
+	go h.do("udp", w, req)
 }
 
-// HandleFailed handles dns failures
+// HandleFailed handles failed DNS queries
 func (h *DNSHandler) HandleFailed(w dns.ResponseWriter, message *dns.Msg) {
 	m := new(dns.Msg)
 	m.SetRcode(message, dns.RcodeServerFailure)
 	h.WriteReplyMsg(w, m)
 }
 
-// WriteReplyMsg writes the dns reply
+// WriteReplyMsg writes the result message for the DNS client
 func (h *DNSHandler) WriteReplyMsg(w dns.ResponseWriter, message *dns.Msg) {
 	defer func() {
 		if r := recover(); r != nil {

--- a/logger.go
+++ b/logger.go
@@ -4,50 +4,97 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/op/go-logging"
 )
 
-// LoggerInit Initializes the logger
-func LoggerInit(logLevel int, logFile string) (*os.File, error) {
-	errorLevel := map[int]logging.Level{
-		0: logging.WARNING,
-		1: logging.INFO,
-		2: logging.DEBUG,
-	}
-	const moduleName = "grimd"
-	logger = logging.MustGetLogger(moduleName)
-	var format = logging.MustStringFormatter(
-		`%{color}%{time:15:04:05.000} %{level:.4s} %{shortfile} ▶ %{id:03x}%{color:reset} %{message}`)
-	stderrBackend := logging.NewLogBackend(os.Stderr, "", 0)
-	stderrFormatter := logging.NewBackendFormatter(stderrBackend, format)
-	stderrLeveled := logging.AddModuleLevel(stderrFormatter)
+var errorLevel = map[int]logging.Level{
+	0: logging.WARNING,
+	1: logging.INFO,
+	2: logging.DEBUG,
+}
 
-	stderrLeveled.SetLevel(errorLevel[logLevel], moduleName)
+func initWriterLogger(logLevel int, writer io.Writer, moduleName string, format string) (logging.LeveledBackend, error) {
+	formatter := logging.MustStringFormatter(format)
+	backend := logging.NewLogBackend(writer, "", 0)
+	backendFormatter := logging.NewBackendFormatter(backend, formatter)
+	module := logging.AddModuleLevel(backendFormatter)
+	module.SetLevel(errorLevel[logLevel], moduleName)
 
-	if _, err := os.Stat(logFile); os.IsNotExist(err) {
-		if _, err := os.Create(logFile); err != nil {
-			return nil, fmt.Errorf("error creating log file: %s", err)
+	return module, nil
+}
+
+func initFileLogger(logLevel int, fileName string, moduleName string, format string) (*os.File, logging.Backend, error) {
+	if _, err := os.Stat(fileName); os.IsNotExist(err) {
+		if _, err := os.Create(fileName); err != nil {
+			return nil, nil, fmt.Errorf("error creating log file: %s", err)
 		}
 	}
 
-	file, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+	file, err := os.OpenFile(fileName, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
 	if err != nil {
-		return nil, fmt.Errorf("error opening log file: %s", err)
+		return nil, nil, fmt.Errorf("error opening log file: %s", err)
 	}
-
-	format = logging.MustStringFormatter(
-		`%{time:15:04:05.000} %{level:.4s} %{shortfile} ▶ %{id:03x} %{message}`)
 	fileWriter := io.Writer(file)
-	fileBackend := logging.NewLogBackend(fileWriter, "", 0)
-	fileFormatter := logging.NewBackendFormatter(fileBackend, format)
-	fileLeveled := logging.AddModuleLevel(fileFormatter)
+	module, err := initWriterLogger(logLevel, fileWriter, moduleName, format)
+	return file, module, err
+}
 
-	fileLeveled.SetLevel(errorLevel[logLevel], moduleName)
+// LoggerInit Initializes the logger
+func LoggerInit(config *Config) []*os.File {
+	var backends []logging.Backend
+	var files []*os.File
 
-	logging.SetBackend(stderrLeveled, fileLeveled)
+	const moduleName = "grimd"
 
-	return file, nil
+	logConfig, err := ParseLogConfig(config.LogConfig)
+	if err != nil {
+		panic(fmt.Sprintf("Cannot parse LogConfig: %s -  %v", config.LogConfig, err))
+	}
+	if logConfig.stderr {
+		stderrBackend, err := initWriterLogger(config.LogLevel, os.Stderr, moduleName, `%{color}%{time:15:04:05.000} %{level:.4s} %{shortfile} ▶ %{id:03x}%{color:reset} %{message}`)
+		if err == nil {
+			backends = append(backends, stderrBackend)
+		}
+	}
+	for _, logFile := range logConfig.files {
+		file, fileBackend, err := initFileLogger(config.LogLevel, logFile, moduleName, `%{time:15:04:05.000} %{level:.4s} %{shortfile} ▶ %{id:03x} %{message}`)
+		if err == nil {
+			backends = append(backends, fileBackend)
+			files = append(files, file)
+		}
+	}
+	logging.SetBackend(backends...)
+	return files
+}
+
+// LogConfig type
+type LogConfig struct {
+	files  []string
+	syslog bool
+	stderr bool
+}
+
+// ParseLogConfig parses a log config string and returns a LogConfig structure
+func ParseLogConfig(config string) (LogConfig, error) {
+	var c = LogConfig{}
+	options := strings.Split(config, ",")
+	for _, option := range options {
+		parts := strings.Split(option, ":")
+		switch parts[0] {
+		case "file":
+			c.files = append(c.files, parts[1])
+			break
+		case "syslog":
+			c.syslog = true
+			break
+		case "stderr":
+			c.stderr = true
+			break
+		}
+	}
+	return c, nil
 }
 
 var (

--- a/logger.go
+++ b/logger.go
@@ -4,100 +4,188 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/op/go-logging"
 )
 
-var errorLevel = map[int]logging.Level{
-	0: logging.WARNING,
-	1: logging.INFO,
-	2: logging.DEBUG,
+type fileConfig struct {
+	name  string
+	level logging.Level
 }
 
-func initWriterLogger(logLevel int, writer io.Writer, moduleName string, format string) (logging.LeveledBackend, error) {
-	formatter := logging.MustStringFormatter(format)
-	backend := logging.NewLogBackend(writer, "", 0)
-	backendFormatter := logging.NewBackendFormatter(backend, formatter)
-	module := logging.AddModuleLevel(backendFormatter)
-	module.SetLevel(errorLevel[logLevel], moduleName)
-
-	return module, nil
+type boolConfig struct {
+	enabled bool
+	level   logging.Level
 }
 
-func initFileLogger(logLevel int, fileName string, moduleName string, format string) (*os.File, logging.Backend, error) {
+type logConfig struct {
+	files  []fileConfig
+	syslog boolConfig
+	stderr boolConfig
+}
+
+func parseLogLevel(level string) (logging.Level, error) {
+	errorLevel := map[int]logging.Level{
+		0: logging.WARNING,
+		1: logging.INFO,
+		2: logging.DEBUG,
+	}
+
+	l, err := strconv.Atoi(level)
+	if err != nil {
+		return logging.CRITICAL, fmt.Errorf("'%s' is not an integer", level)
+	}
+
+	if l < 0 || l > 2 {
+		return logging.CRITICAL, fmt.Errorf("'%s' is not a valid value. Valid values: 0,1,2", level)
+	}
+
+	return errorLevel[l], nil
+}
+
+func parseLogConfig(logConfigString string) (*logConfig, error) {
+	var result logConfig
+	fileRe := regexp.MustCompile(`file:([^@]+)@(\S+)`)
+	boolRe := regexp.MustCompile(`(syslog|stderr)@(\S+)`)
+
+	for _, part := range strings.Split(logConfigString, ",") {
+
+		match := fileRe.FindStringSubmatch(part)
+		if match != nil {
+			l, err := parseLogLevel(match[2])
+			if err != nil {
+				return nil, fmt.Errorf("Error while parsing '%s': %s", match[0], err.Error())
+			}
+			result.files = append(result.files, fileConfig{match[1], l})
+			continue
+		}
+
+		match = boolRe.FindStringSubmatch(part)
+		fmt.Printf("%s", part)
+		fmt.Printf("%q", match)
+		if match != nil {
+			l, err := parseLogLevel(match[2])
+			if err != nil {
+				return nil, fmt.Errorf("Error while parsing '%s': %s", match[0], err.Error())
+			}
+			switch match[1] {
+			case "syslog":
+				result.syslog = boolConfig{true, l}
+				continue
+			case "stderr":
+				result.stderr = boolConfig{true, l}
+				continue
+			}
+		}
+
+		return nil, fmt.Errorf("Error: uknown log config fragment: '%s'", part)
+
+	}
+	return &result, nil
+}
+
+func createLogFile(fileName string) (*os.File, error) {
 	if _, err := os.Stat(fileName); os.IsNotExist(err) {
 		if _, err := os.Create(fileName); err != nil {
-			return nil, nil, fmt.Errorf("error creating log file: %s", err)
+			return nil, fmt.Errorf("error creating log file '%s': %s", fileName, err)
 		}
 	}
 
 	file, err := os.OpenFile(fileName, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error opening log file: %s", err)
+		return nil, fmt.Errorf("error opening log file: %s", err)
 	}
-	fileWriter := io.Writer(file)
-	module, err := initWriterLogger(logLevel, fileWriter, moduleName, format)
-	return file, module, err
+
+	return file, nil
+}
+
+func decorateBackend(backend logging.Backend, level logging.Level, format string, moduleName string) logging.LeveledBackend {
+	stringFormatter := logging.MustStringFormatter(format)
+	beFormatter := logging.NewBackendFormatter(backend, stringFormatter)
+	leveled := logging.AddModuleLevel(beFormatter)
+	leveled.SetLevel(level, moduleName)
+	return leveled
+}
+
+func createLoggerFromFile(file *os.File, level logging.Level, format string, moduleName string) logging.LeveledBackend {
+	writer := io.Writer(file)
+	backend := logging.NewLogBackend(writer, "", 0)
+	return decorateBackend(backend, level, format, moduleName)
+}
+
+func createFileLogger(cfg fileConfig, moduleName string) (*logging.LeveledBackend, *os.File, error) {
+	file, err := createLogFile(cfg.name)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	formatString := `%{time:15:04:05.000} %{level:.4s} %{shortfile} ▶ %{id:03x} %{message}`
+	backend := createLoggerFromFile(file, cfg.level, formatString, moduleName)
+	return &backend, file, nil
+}
+
+func creatSyslogBackend(cfg boolConfig, moduleName string) (*logging.LeveledBackend, error) {
+	backend, err := logging.NewSyslogBackend("Grimd")
+	if err != nil {
+		return nil, err
+	}
+	format := `%{time:15:04:05.000} %{level:.4s} %{shortfile} ▶ %{id:03x} %{message}`
+	decorated := decorateBackend(backend, cfg.level, format, moduleName)
+	return &decorated, nil
 }
 
 // LoggerInit Initializes the logger
-func LoggerInit(config *Config) []*os.File {
-	var backends []logging.Backend
-	var files []*os.File
+func LoggerInit(cfg string) ([]*os.File, error) {
+
+	logConfig, err := parseLogConfig(cfg)
+	if err != nil {
+		panic(err)
+	}
+
+	//fmt.Printf("%d", errorLevel[0])
+	//fmt.Printf("%#v", logConfig)
 
 	const moduleName = "grimd"
+	logger = logging.MustGetLogger(moduleName)
 
-	logConfig, err := ParseLogConfig(config.LogConfig)
-	if err != nil {
-		panic(fmt.Sprintf("Cannot parse LogConfig: %s -  %v", config.LogConfig, err))
-	}
-	if logConfig.stderr {
-		stderrBackend, err := initWriterLogger(config.LogLevel, os.Stderr, moduleName, `%{color}%{time:15:04:05.000} %{level:.4s} %{shortfile} ▶ %{id:03x}%{color:reset} %{message}`)
-		if err == nil {
-			backends = append(backends, stderrBackend)
+	var backends []logging.Backend
+	var openFiles []*os.File
+
+	for _, f := range logConfig.files {
+		b, file, err := createFileLogger(f, moduleName)
+		if err != nil {
+			for _, toClose := range openFiles {
+				toClose.Close()
+			}
+			return nil, err
 		}
+		backends = append(backends, *b)
+		openFiles = append(openFiles, file)
 	}
-	for _, logFile := range logConfig.files {
-		file, fileBackend, err := initFileLogger(config.LogLevel, logFile, moduleName, `%{time:15:04:05.000} %{level:.4s} %{shortfile} ▶ %{id:03x} %{message}`)
-		if err == nil {
-			backends = append(backends, fileBackend)
-			files = append(files, file)
+
+	if logConfig.stderr.enabled {
+		var format = `%{color}%{time:15:04:05.000} %{level:.4s} %{shortfile} ▶ %{id:03x}%{color:reset} %{message}`
+		stderrLogger := createLoggerFromFile(os.Stderr, logConfig.stderr.level, format, moduleName)
+		backends = append(backends, stderrLogger)
+	}
+
+	if logConfig.syslog.enabled {
+		syslogLogger, err := creatSyslogBackend(logConfig.syslog, moduleName)
+		if err != nil {
+			panic(err)
 		}
+		backends = append(backends, *syslogLogger)
 	}
+
 	logging.SetBackend(backends...)
-	return files
-}
 
-// LogConfig type
-type LogConfig struct {
-	files  []string
-	syslog bool
-	stderr bool
-}
-
-// ParseLogConfig parses a log config string and returns a LogConfig structure
-func ParseLogConfig(config string) (LogConfig, error) {
-	var c = LogConfig{}
-	options := strings.Split(config, ",")
-	for _, option := range options {
-		parts := strings.Split(option, ":")
-		switch parts[0] {
-		case "file":
-			c.files = append(c.files, parts[1])
-			break
-		case "syslog":
-			c.syslog = true
-			break
-		case "stderr":
-			c.stderr = true
-			break
-		}
-	}
-	return c, nil
+	return openFiles, nil
 }
 
 var (
 	// Initialize to a dummy but functional logger so that tested code has something to write to
-	logger = logging.MustGetLogger("test")
+	logger *logging.Logger = logging.MustGetLogger("test")
 )

--- a/logger.go
+++ b/logger.go
@@ -10,20 +10,20 @@ import (
 
 // LoggerInit Initializes the logger
 func LoggerInit(logLevel int, logFile string) (*os.File, error) {
-	error_level := map[int]logging.Level{
+	errorLevel := map[int]logging.Level{
 		0: logging.WARNING,
 		1: logging.INFO,
 		2: logging.DEBUG,
 	}
-	const module_name = "grimd"
-	logger = logging.MustGetLogger(module_name)
+	const moduleName = "grimd"
+	logger = logging.MustGetLogger(moduleName)
 	var format = logging.MustStringFormatter(
 		`%{color}%{time:15:04:05.000} %{level:.4s} %{shortfile} ▶ %{id:03x}%{color:reset} %{message}`)
-	stderr_backend := logging.NewLogBackend(os.Stderr, "", 0)
-	stderr_formatter := logging.NewBackendFormatter(stderr_backend, format)
-	stderr_leveled := logging.AddModuleLevel(stderr_formatter)
+	stderrBackend := logging.NewLogBackend(os.Stderr, "", 0)
+	stderrFormatter := logging.NewBackendFormatter(stderrBackend, format)
+	stderrLeveled := logging.AddModuleLevel(stderrFormatter)
 
-	stderr_leveled.SetLevel(error_level[logLevel], module_name)
+	stderrLeveled.SetLevel(errorLevel[logLevel], moduleName)
 
 	if _, err := os.Stat(logFile); os.IsNotExist(err) {
 		if _, err := os.Create(logFile); err != nil {
@@ -38,19 +38,19 @@ func LoggerInit(logLevel int, logFile string) (*os.File, error) {
 
 	format = logging.MustStringFormatter(
 		`%{time:15:04:05.000} %{level:.4s} %{shortfile} ▶ %{id:03x} %{message}`)
-	file_writer := io.Writer(file)
-	file_backend := logging.NewLogBackend(file_writer, "", 0)
-	file_formatter := logging.NewBackendFormatter(file_backend, format)
-	file_leveled := logging.AddModuleLevel(file_formatter)
+	fileWriter := io.Writer(file)
+	fileBackend := logging.NewLogBackend(fileWriter, "", 0)
+	fileFormatter := logging.NewBackendFormatter(fileBackend, format)
+	fileLeveled := logging.AddModuleLevel(fileFormatter)
 
-	file_leveled.SetLevel(error_level[logLevel], module_name)
+	fileLeveled.SetLevel(errorLevel[logLevel], moduleName)
 
-	logging.SetBackend(stderr_leveled, file_leveled)
+	logging.SetBackend(stderrLeveled, fileLeveled)
 
 	return file, nil
 }
 
 var (
 	// Initialize to a dummy but functional logger so that tested code has something to write to
-	logger *logging.Logger = logging.MustGetLogger("test")
+	logger = logging.MustGetLogger("test")
 )

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestThatCanFindOneFile(t *testing.T) {
+	var logConfigString = "file:some.file,null,unknown:thin.g"
+	logConfig, err := ParseLogConfig(logConfigString)
+	assert.Nil(t, err)
+	assert.NotNil(t, logConfig)
+	assert.Equal(t, len(logConfig.files), 1)
+	assert.Equal(t, logConfig.files[0], "some.file")
+	assert.False(t, logConfig.syslog)
+}
+
+func TestThatSysLogWorks(t *testing.T) {
+	var logConfigString = "whatever"
+	logConfig, err := ParseLogConfig(logConfigString)
+	assert.Nil(t, err)
+	assert.False(t, logConfig.syslog)
+	logConfigString = "syslog"
+	logConfig, err = ParseLogConfig(logConfigString)
+	assert.Nil(t, err)
+	assert.True(t, logConfig.syslog)
+	logConfigString = "syslog,file:some.file"
+	logConfig, err = ParseLogConfig(logConfigString)
+	assert.Nil(t, err)
+	assert.True(t, logConfig.syslog)
+	logConfigString = "file:some.file,syslog"
+	logConfig, err = ParseLogConfig(logConfigString)
+	assert.Nil(t, err)
+	assert.True(t, logConfig.syslog)
+	logConfigString = "file:some.file,syslog,file:whaaaaat"
+	logConfig, err = ParseLogConfig(logConfigString)
+	assert.Nil(t, err)
+	assert.True(t, logConfig.syslog)
+	logConfigString = "file:some.file,file:test,syslog"
+	logConfig, err = ParseLogConfig(logConfigString)
+	assert.Nil(t, err)
+	assert.True(t, logConfig.syslog)
+	logConfigString = "file:syslog"
+	logConfig, err = ParseLogConfig(logConfigString)
+	assert.Nil(t, err)
+	assert.False(t, logConfig.syslog)
+	assert.Equal(t, "syslog", logConfig.files[0])
+	logConfigString = "wrong:entry,syslog"
+	logConfig, err = ParseLogConfig(logConfigString)
+	assert.Nil(t, err)
+	assert.True(t, logConfig.syslog)
+	logConfigString = "syslog,wrong:entry"
+	logConfig, err = ParseLogConfig(logConfigString)
+	assert.Nil(t, err)
+	assert.True(t, logConfig.syslog)
+	logConfigString = "syslog,file:entry,syslog"
+	logConfig, err = ParseLogConfig(logConfigString)
+	assert.Nil(t, err)
+	assert.True(t, logConfig.syslog)
+}
+
+func TestThatStdErrWorks(t *testing.T) {
+	var logConfigString = "whatever"
+	logConfig, err := ParseLogConfig(logConfigString)
+	assert.Nil(t, err)
+	assert.False(t, logConfig.stderr)
+	logConfigString = "stderr"
+	logConfig, err = ParseLogConfig(logConfigString)
+	assert.Nil(t, err)
+	assert.True(t, logConfig.stderr)
+	logConfigString = "stderr,file:some.file"
+	logConfig, err = ParseLogConfig(logConfigString)
+	assert.Nil(t, err)
+	assert.True(t, logConfig.stderr)
+	logConfigString = "file:some.file,stderr"
+	logConfig, err = ParseLogConfig(logConfigString)
+	assert.Nil(t, err)
+	assert.True(t, logConfig.stderr)
+	logConfigString = "file:some.file,stderr,file:whaaaaat"
+	logConfig, err = ParseLogConfig(logConfigString)
+	assert.Nil(t, err)
+	assert.True(t, logConfig.stderr)
+	logConfigString = "file:some.file,file:test,stderr"
+	logConfig, err = ParseLogConfig(logConfigString)
+	assert.Nil(t, err)
+	assert.True(t, logConfig.stderr)
+	logConfigString = "file:stderr"
+	logConfig, err = ParseLogConfig(logConfigString)
+	assert.Nil(t, err)
+	assert.False(t, logConfig.stderr)
+	assert.Equal(t, "stderr", logConfig.files[0])
+	logConfigString = "wrong:entry,stderr"
+	logConfig, err = ParseLogConfig(logConfigString)
+	assert.Nil(t, err)
+	assert.True(t, logConfig.stderr)
+	logConfigString = "stderr,wrong:entry"
+	logConfig, err = ParseLogConfig(logConfigString)
+	assert.Nil(t, err)
+	assert.True(t, logConfig.stderr)
+	logConfigString = "stderr,file:entry,stderr"
+	logConfig, err = ParseLogConfig(logConfigString)
+	assert.Nil(t, err)
+	assert.True(t, logConfig.stderr)
+}

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,105 +1,199 @@
 package main
 
 import (
+	"fmt"
+	"io/ioutil"
+	"os"
 	"testing"
+
+	"github.com/op/go-logging"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestThatCanFindOneFile(t *testing.T) {
-	var logConfigString = "file:some.file,null,unknown:thin.g"
-	logConfig, err := ParseLogConfig(logConfigString)
-	assert.Nil(t, err)
-	assert.NotNil(t, logConfig)
-	assert.Equal(t, len(logConfig.files), 1)
-	assert.Equal(t, logConfig.files[0], "some.file")
-	assert.False(t, logConfig.syslog)
+func TestLogConfigParsing(t *testing.T) {
+	var fileTests = []struct {
+		in  string
+		out *logConfig
+		err error
+	}{
+		{
+			in: "file:grimd.log@0",
+			out: &logConfig{
+				files: []fileConfig{
+					fileConfig{
+						name:  "grimd.log",
+						level: logging.WARNING,
+					},
+				},
+			},
+			err: nil,
+		},
+		{
+			in: "file:grimd.log@0,file:something.log@1",
+			out: &logConfig{
+				files: []fileConfig{
+					fileConfig{
+						name:  "grimd.log",
+						level: 0,
+					},
+					fileConfig{
+						name:  "something.log",
+						level: logging.INFO,
+					},
+				},
+			},
+			err: nil,
+		},
+		{
+			in:  "file:grimd.log@aa",
+			out: nil,
+			err: fmt.Errorf("Error while parsing 'file:grimd.log@aa': 'aa' is not an integer"),
+		},
+		{
+			in:  "syslog@aa",
+			out: nil,
+			err: fmt.Errorf("Error while parsing 'syslog@aa': 'aa' is not an integer"),
+		},
+		{
+			in:  "fail:grimd.log@1",
+			out: nil,
+			err: fmt.Errorf("Error: uknown log config fragment: 'fail:grimd.log@1'"),
+		},
+		{
+			in: "syslog@0",
+			out: &logConfig{
+				syslog: boolConfig{
+					enabled: true,
+					level:   logging.WARNING,
+				},
+			},
+			err: nil,
+		},
+		{
+			in: "file:grimd.log@1,syslog@1",
+			out: &logConfig{
+				files: []fileConfig{
+					fileConfig{
+						name:  "grimd.log",
+						level: logging.INFO,
+					},
+				},
+				syslog: boolConfig{
+					enabled: true,
+					level:   logging.INFO,
+				},
+			},
+			err: nil,
+		},
+		{
+			in: "stderr@2",
+			out: &logConfig{
+				stderr: boolConfig{
+					enabled: true,
+					level:   logging.DEBUG,
+				},
+			},
+			err: nil,
+		},
+		{
+			in: "file:grimd.log@2,syslog@1,stderr@0",
+			out: &logConfig{
+				files: []fileConfig{
+					fileConfig{
+						name:  "grimd.log",
+						level: logging.DEBUG,
+					},
+				},
+				syslog: boolConfig{
+					enabled: true,
+					level:   logging.INFO,
+				},
+				stderr: boolConfig{
+					enabled: true,
+					level:   logging.WARNING,
+				},
+			},
+			err: nil,
+		},
+	}
+
+	for _, test := range fileTests {
+		t.Run(test.in, func(t *testing.T) {
+			result, err := parseLogConfig(test.in)
+			if err == nil {
+				assert.Equal(t, test.out, result)
+			} else {
+				assert.Equal(t, test.err, err)
+			}
+		})
+	}
+
 }
 
-func TestThatSysLogWorks(t *testing.T) {
-	var logConfigString = "whatever"
-	logConfig, err := ParseLogConfig(logConfigString)
+func TestCreateLogFile(t *testing.T) {
+	dir, err := ioutil.TempDir("", "test")
 	assert.Nil(t, err)
-	assert.False(t, logConfig.syslog)
-	logConfigString = "syslog"
-	logConfig, err = ParseLogConfig(logConfigString)
-	assert.Nil(t, err)
-	assert.True(t, logConfig.syslog)
-	logConfigString = "syslog,file:some.file"
-	logConfig, err = ParseLogConfig(logConfigString)
-	assert.Nil(t, err)
-	assert.True(t, logConfig.syslog)
-	logConfigString = "file:some.file,syslog"
-	logConfig, err = ParseLogConfig(logConfigString)
-	assert.Nil(t, err)
-	assert.True(t, logConfig.syslog)
-	logConfigString = "file:some.file,syslog,file:whaaaaat"
-	logConfig, err = ParseLogConfig(logConfigString)
-	assert.Nil(t, err)
-	assert.True(t, logConfig.syslog)
-	logConfigString = "file:some.file,file:test,syslog"
-	logConfig, err = ParseLogConfig(logConfigString)
-	assert.Nil(t, err)
-	assert.True(t, logConfig.syslog)
-	logConfigString = "file:syslog"
-	logConfig, err = ParseLogConfig(logConfigString)
-	assert.Nil(t, err)
-	assert.False(t, logConfig.syslog)
-	assert.Equal(t, "syslog", logConfig.files[0])
-	logConfigString = "wrong:entry,syslog"
-	logConfig, err = ParseLogConfig(logConfigString)
-	assert.Nil(t, err)
-	assert.True(t, logConfig.syslog)
-	logConfigString = "syslog,wrong:entry"
-	logConfig, err = ParseLogConfig(logConfigString)
-	assert.Nil(t, err)
-	assert.True(t, logConfig.syslog)
-	logConfigString = "syslog,file:entry,syslog"
-	logConfig, err = ParseLogConfig(logConfigString)
-	assert.Nil(t, err)
-	assert.True(t, logConfig.syslog)
+	defer os.RemoveAll(dir)
+
+	var testCases = []struct {
+		in  string
+		out *os.File
+		err error
+	}{
+		{
+			in:  "",
+			err: fmt.Errorf("error creating log file '': open : no such file or directory"),
+		},
+		{
+			in:  fmt.Sprintf("%s/first", dir),
+			err: nil,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.in, func(t *testing.T) {
+			result, err := createLogFile(test.in)
+			assert.Equal(t, test.err, err)
+			if err == nil {
+				assert.NotNil(t, result)
+				result.Close()
+				os.Remove(test.in)
+			}
+		})
+	}
 }
 
-func TestThatStdErrWorks(t *testing.T) {
-	var logConfigString = "whatever"
-	logConfig, err := ParseLogConfig(logConfigString)
+func TestCreateFileLogger(t *testing.T) {
+	dir, err := ioutil.TempDir("", "test")
 	assert.Nil(t, err)
-	assert.False(t, logConfig.stderr)
-	logConfigString = "stderr"
-	logConfig, err = ParseLogConfig(logConfigString)
+	defer os.RemoveAll(dir)
+
+	var testCases = []struct {
+		in  string
+		err error
+	}{
+		{
+			in:  fmt.Sprintf("%s/one", dir),
+			err: nil,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.in, func(t *testing.T) {
+			cfg := fileConfig{tc.in, logging.WARNING}
+			logger, file, err := createFileLogger(cfg, "module")
+			assert.Equal(t, tc.err, err)
+			if err == nil {
+				assert.NotNil(t, logger)
+				assert.NotNil(t, file)
+				file.Close()
+			}
+		})
+	}
+}
+
+func TestLogLevelParse(t *testing.T) {
+	l, err := parseLogLevel("0")
 	assert.Nil(t, err)
-	assert.True(t, logConfig.stderr)
-	logConfigString = "stderr,file:some.file"
-	logConfig, err = ParseLogConfig(logConfigString)
-	assert.Nil(t, err)
-	assert.True(t, logConfig.stderr)
-	logConfigString = "file:some.file,stderr"
-	logConfig, err = ParseLogConfig(logConfigString)
-	assert.Nil(t, err)
-	assert.True(t, logConfig.stderr)
-	logConfigString = "file:some.file,stderr,file:whaaaaat"
-	logConfig, err = ParseLogConfig(logConfigString)
-	assert.Nil(t, err)
-	assert.True(t, logConfig.stderr)
-	logConfigString = "file:some.file,file:test,stderr"
-	logConfig, err = ParseLogConfig(logConfigString)
-	assert.Nil(t, err)
-	assert.True(t, logConfig.stderr)
-	logConfigString = "file:stderr"
-	logConfig, err = ParseLogConfig(logConfigString)
-	assert.Nil(t, err)
-	assert.False(t, logConfig.stderr)
-	assert.Equal(t, "stderr", logConfig.files[0])
-	logConfigString = "wrong:entry,stderr"
-	logConfig, err = ParseLogConfig(logConfigString)
-	assert.Nil(t, err)
-	assert.True(t, logConfig.stderr)
-	logConfigString = "stderr,wrong:entry"
-	logConfig, err = ParseLogConfig(logConfigString)
-	assert.Nil(t, err)
-	assert.True(t, logConfig.stderr)
-	logConfigString = "stderr,file:entry,stderr"
-	logConfig, err = ParseLogConfig(logConfigString)
-	assert.Nil(t, err)
-	assert.True(t, logConfig.stderr)
+	assert.Equal(t, logging.WARNING, l)
 }

--- a/main.go
+++ b/main.go
@@ -46,11 +46,10 @@ func main() {
 		logger.Fatal(err)
 	}
 
-	logFile, err := LoggerInit(config.LogLevel, config.Log)
-	if err != nil {
-		logger.Fatal(err)
+	files := LoggerInit(config)
+	for _, file := range files {
+		defer file.Close()
 	}
-	defer logFile.Close()
 
 	grimdActive = true
 	quitActivation := make(chan bool)

--- a/main.go
+++ b/main.go
@@ -1,10 +1,9 @@
 package main
 
 import (
-	"context"
 	"flag"
-	"net/http"
 	"os"
+	"os/signal"
 	"runtime"
 	"time"
 )
@@ -14,74 +13,70 @@ var (
 	forceUpdate     bool
 	grimdActive     bool
 	grimdActivation ActivationHandler
+
+	// BlockCache contains all blocked domains
+	BlockCache = &MemoryBlockCache{Backend: make(map[string]bool)}
+
+	// QuestionCache contains all queries to the dns server
+	QuestionCache = &MemoryQuestionCache{Backend: make([]QuestionCacheEntry, 0), Maxcount: 1000}
 )
 
-func reloadBlockCache(config *Config,
-	blockCache *MemoryBlockCache,
-	questionCache *MemoryQuestionCache,
-	apiServer *http.Server,
-	server *Server,
-	reloadChan chan bool) (*MemoryBlockCache, *http.Server, error) {
-	logger.Debug("Reloading the blockcache")
-	blockCache = PerformUpdate(config, true)
-	server.Stop()
-	if apiServer != nil {
-		apiServer.Shutdown(context.Background())
-	}
-	server.Run(config, blockCache, questionCache)
-	apiServer, err := StartAPIServer(config, reloadChan, blockCache, questionCache)
-	if err != nil {
-		logger.Fatal(err)
-		return nil, nil, err
-	}
-
-	return blockCache, apiServer, nil
-}
-
 func main() {
+
 	flag.Parse()
 
-	config, err := LoadConfig(configPath)
-	if err != nil {
+	if err := LoadConfig(configPath); err != nil {
 		logger.Fatal(err)
 	}
 
-	files := LoggerInit(config)
-	for _, file := range files {
-		defer file.Close()
+	QuestionCache.Maxcount = Config.QuestionCacheCap
+
+	logFiles, err := LoggerInit(Config.LogConfig)
+	if err != nil {
+		logger.Fatal(err)
 	}
+	defer func() {
+		for _, f := range logFiles {
+			f.Close()
+		}
+	}()
+
+	// delay updating the blocklists, cache until the server starts and can serve requests as the local resolver
+	startUpdate := make(chan bool, 1)
+
+	//abort if the server does not come up in 10 seconds
+	timer := time.NewTimer(time.Second * 10)
+	go func() {
+		<-timer.C
+		startUpdate <- false
+	}()
+
+	go func() {
+		run := <-startUpdate
+		if !run {
+			panic("The DNS server did not start in 10 seconds")
+		}
+		PerformUpdate(forceUpdate)
+	}()
 
 	grimdActive = true
 	quitActivation := make(chan bool)
-	go grimdActivation.loop(quitActivation, config.ReactivationDelay)
+	go grimdActivation.loop(quitActivation)
 
 	server := &Server{
-		host:     config.Bind,
+		host:     Config.Bind,
 		rTimeout: 5 * time.Second,
 		wTimeout: 5 * time.Second,
 	}
 
-	// BlockCache contains all blocked domains
-	blockCache := &MemoryBlockCache{Backend: make(map[string]bool)}
-	// QuestionCache contains all queries to the dns server
-	questionCache := &MemoryQuestionCache{Backend: make([]QuestionCacheEntry, 0), Maxcount: 1000}
-	questionCache.Maxcount = config.QuestionCacheCap
+	server.Run(startUpdate)
 
-	reloadChan := make(chan bool)
-
-	// The server will start with an empty blockcache soe we can dowload the lists if grimd is the
-	// system's dns server.
-	server.Run(config, blockCache, questionCache)
-
-	var apiServer *http.Server
-	// Load the block cache, restart the server with the new context
-	blockCache, apiServer, err = reloadBlockCache(config, blockCache, questionCache, apiServer, server, reloadChan)
-
-	if err != nil {
-		logger.Fatalf("Cannot start the API server %s", err)
+	if err := StartAPIServer(); err != nil {
+		logger.Fatal(err)
 	}
 
 	sig := make(chan os.Signal)
+	signal.Notify(sig, os.Interrupt)
 
 forever:
 	for {
@@ -90,11 +85,6 @@ forever:
 			logger.Error("signal received, stopping\n")
 			quitActivation <- true
 			break forever
-		case <-reloadChan:
-			blockCache, apiServer, err = reloadBlockCache(config, blockCache, questionCache, apiServer, server, reloadChan)
-			if err != nil {
-				logger.Fatalf("Cannot start the API server %s", err)
-			}
 		}
 	}
 }

--- a/server.go
+++ b/server.go
@@ -8,60 +8,44 @@ import (
 
 // Server type
 type Server struct {
-	host      string
-	rTimeout  time.Duration
-	wTimeout  time.Duration
-	handler   *DNSHandler
-	udpServer *dns.Server
-	tcpServer *dns.Server
+	host     string
+	rTimeout time.Duration
+	wTimeout time.Duration
 }
 
 // Run starts the server
-func (s *Server) Run(config *Config,
-	blockCache *MemoryBlockCache,
-	questionCache *MemoryQuestionCache) {
-	s.handler = NewHandler(config, blockCache, questionCache)
+func (s *Server) Run(updateLists chan bool) {
+	Handler := NewHandler()
 
 	tcpHandler := dns.NewServeMux()
-	tcpHandler.HandleFunc(".", s.handler.DoTCP)
+	tcpHandler.HandleFunc(".", Handler.DoTCP)
 
 	udpHandler := dns.NewServeMux()
-	udpHandler.HandleFunc(".", s.handler.DoUDP)
+	udpHandler.HandleFunc(".", Handler.DoUDP)
 
-	s.tcpServer = &dns.Server{Addr: s.host,
+	tcpServer := &dns.Server{Addr: s.host,
 		Net:          "tcp",
 		Handler:      tcpHandler,
 		ReadTimeout:  s.rTimeout,
 		WriteTimeout: s.wTimeout}
 
-	s.udpServer = &dns.Server{Addr: s.host,
+	udpServer := &dns.Server{Addr: s.host,
 		Net:          "udp",
 		Handler:      udpHandler,
 		UDPSize:      65535,
 		ReadTimeout:  s.rTimeout,
 		WriteTimeout: s.wTimeout}
 
-	go s.start(s.udpServer)
-	go s.start(s.tcpServer)
+	go s.start(udpServer)
+	go s.start(tcpServer)
+
+	updateLists <- true
 }
 
 func (s *Server) start(ds *dns.Server) {
-	logger.Criticalf("start %s listener on %s\n", ds.Net, s.host)
+	logger.Errorf("start %s listener on %s\n", ds.Net, s.host)
 
 	if err := ds.ListenAndServe(); err != nil {
-		logger.Criticalf("start %s listener on %s failed: %s\n", ds.Net, s.host, err.Error())
-	}
-}
-
-// Stop stops the server
-func (s *Server) Stop() {
-	if s.handler != nil {
-		close(s.handler.requestChannel)
-	}
-	if s.udpServer != nil {
-		s.udpServer.Shutdown()
-	}
-	if s.tcpServer != nil {
-		s.tcpServer.Shutdown()
+		logger.Errorf("start %s listener on %s failed: %s\n", ds.Net, s.host, err.Error())
 	}
 }

--- a/updater.go
+++ b/updater.go
@@ -16,22 +16,22 @@ var timesSeen = make(map[string]int)
 var whitelist = make(map[string]bool)
 
 // Update downloads all of the blocklists and imports them into the database
-func update(blockCache *MemoryBlockCache, wlist []string, blist []string, sources []string) error {
+func update(blockCache *MemoryBlockCache) error {
 	if _, err := os.Stat("sources"); os.IsNotExist(err) {
 		if err := os.Mkdir("sources", 0700); err != nil {
 			return fmt.Errorf("error creating sources directory: %s", err)
 		}
 	}
 
-	for _, entry := range wlist {
+	for _, entry := range Config.Whitelist {
 		whitelist[entry] = true
 	}
 
-	for _, entry := range blist {
+	for _, entry := range Config.Blocklist {
 		blockCache.Set(entry, true)
 	}
 
-	if err := fetchSources(sources); err != nil {
+	if err := fetchSources(); err != nil {
 		return fmt.Errorf("error fetching sources: %s", err)
 	}
 
@@ -60,10 +60,10 @@ func downloadFile(uri string, name string) error {
 	return nil
 }
 
-func fetchSources(sources []string) error {
+func fetchSources() error {
 	var wg sync.WaitGroup
 
-	for _, uri := range sources {
+	for _, uri := range Config.Sources {
 		wg.Add(1)
 
 		u, _ := url.Parse(uri)
@@ -87,10 +87,10 @@ func fetchSources(sources []string) error {
 }
 
 // UpdateBlockCache updates the BlockCache
-func updateBlockCache(blockCache *MemoryBlockCache, sourceDirs []string) error {
-	logger.Debugf("loading blocked domains from %d locations...\n", len(sourceDirs))
+func updateBlockCache(blockCache *MemoryBlockCache) error {
+	logger.Debugf("loading blocked domains from %d locations...\n", len(Config.SourceDirs))
 
-	for _, dir := range sourceDirs {
+	for _, dir := range Config.SourceDirs {
 		if _, err := os.Stat(dir); os.IsNotExist(err) {
 			logger.Errorf("directory %s not found, skipping\n", dir)
 			continue
@@ -98,9 +98,13 @@ func updateBlockCache(blockCache *MemoryBlockCache, sourceDirs []string) error {
 
 		err := filepath.Walk(dir, func(path string, f os.FileInfo, _ error) error {
 			if !f.IsDir() {
-				fileName := filepath.FromSlash(path)
+				file, err := os.Open(filepath.FromSlash(path))
+				if err != nil {
+					return fmt.Errorf("error opening file: %s", err)
+				}
+				defer file.Close()
 
-				if err := parseHostFile(fileName, blockCache); err != nil {
+				if err = parseHostFile(file, blockCache); err != nil {
 					return fmt.Errorf("error parsing hostfile %s", err)
 				}
 			}
@@ -118,22 +122,17 @@ func updateBlockCache(blockCache *MemoryBlockCache, sourceDirs []string) error {
 	return nil
 }
 
-func parseHostFile(fileName string, blockCache *MemoryBlockCache) error {
-	file, err := os.Open(fileName)
-	if err != nil {
-		return fmt.Errorf("error opening file: %s", err)
-	}
-	defer file.Close()
+func parseHostFile(file *os.File, blockCache *MemoryBlockCache) error {
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
 		line := scanner.Text()
-		line = strings.Split(line, "#")[0]
 		line = strings.TrimSpace(line)
+		isComment := strings.HasPrefix(line, "#")
 
-		if len(line) > 0 {
+		if !isComment && line != "" {
 			fields := strings.Fields(line)
 
-			if len(fields) > 1 {
+			if len(fields) > 1 && !strings.HasPrefix(fields[1], "#") {
 				line = fields[1]
 			} else {
 				line = fields[0]
@@ -152,18 +151,23 @@ func parseHostFile(fileName string, blockCache *MemoryBlockCache) error {
 	return nil
 }
 
-// PerformUpdate updates the block cache by building a new one and swapping
+// PerformUpdate performs the update of the block cache by building a new cache and swapping
 // it for the old cache.
-func PerformUpdate(config *Config, forceUpdate bool) *MemoryBlockCache {
+func PerformUpdate(forceUpdate bool) {
 	newBlockCache := &MemoryBlockCache{Backend: make(map[string]bool)}
 	if _, err := os.Stat("lists"); os.IsNotExist(err) || forceUpdate {
-		if err := update(newBlockCache, config.Whitelist, config.Blocklist, config.Sources); err != nil {
+		if err := update(newBlockCache); err != nil {
 			logger.Fatal(err)
 		}
 	}
-	if err := updateBlockCache(newBlockCache, config.SourceDirs); err != nil {
+	if err := updateBlockCache(newBlockCache); err != nil {
 		logger.Fatal(err)
 	}
 
-	return newBlockCache
+	oldBlockCache := BlockCache
+	oldBlockCache.mu.Lock()
+	newBlockCache.mu.Lock()
+	BlockCache = newBlockCache
+	newBlockCache.mu.Unlock()
+	oldBlockCache.mu.Unlock()
 }


### PR DESCRIPTION
This changes the configuration file so that it is possible to independently configure the log methods and their log level.

e.g. to enable logging to syslog, stderr, and a file named grimd.log: 
logconfig="syslog@0,file:grimd.log@2,stderr@2"
