### PR TITLE
Added drbl-peer support.

### DIFF
--- a/config.go
+++ b/config.go
@@ -14,10 +14,10 @@ import (
 )
 
 // BuildVersion returns the build version of grimd, this should be incremented every new release
-var BuildVersion = "1.0.6"
+var BuildVersion = "1.0.7"
 
 // ConfigVersion returns the version of grimd, this should be incremented every time the config changes so grimd presents a warning
-var ConfigVersion = "1.0.3"
+var ConfigVersion = "1.0.4"
 
 type config struct {
 	Version           string
@@ -43,6 +43,12 @@ type config struct {
 	WebPanel          bool
 	WebUser           string
 	WebPass           string
+        UseDrbl              int
+        DrblPeersFilename    string
+        DrblBlockWeight      int64
+        DrblTimeout          int
+        DrblDebug            int
+
 }
 
 var defaultConfig = `# version this config was generated from
@@ -112,6 +118,14 @@ questioncachecap = 5000
 
 # manual blocklist entries
 blocklist = []
+
+# Drbl related settings
+usedrbl = 0
+drblpeersfilename = "drblpeers.yaml"
+drblblockweight = 128
+drbltimeout = 30
+drbldebug = 0
+
 
 # manual whitelist entries
 whitelist = [

--- a/drbl.go
+++ b/drbl.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"log"
+	"strings"
+)
+
+func drblCheckHostname(hostname string) bool {
+	testhost := ""
+	verdict := false
+	if strings.HasSuffix(hostname, ".") {
+		testhost = string(hostname[:len(hostname)-1])
+		if Config.LogLevel > 0 {
+			log.Println("a root query:", hostname)
+		}
+	} else {
+		testhost = string(hostname)
+		if Config.LogLevel > 0 {
+			log.Println("not a root query:", hostname)
+		}
+	}
+	block, weight := drblPeers.Check(testhost)
+	if block {
+		verdict = true
+		if Config.LogLevel > 0 {
+			log.Println("DNS query:", testhost, "Got blocked with weigth", weight)
+		}
+	}
+	return verdict
+}

--- a/handler.go
+++ b/handler.go
@@ -138,11 +138,23 @@ func (h *DNSHandler) do(Net string, w dns.ResponseWriter, req *dns.Msg) {
 	}
 	// Check blocklist
 	var blacklisted = false
+	var drblblacklisted bool = false
 
 	if IPQuery > 0 {
 		blacklisted = BlockCache.Exists(Q.Qname)
 
-		if grimdActive && blacklisted {
+		if Config.UseDrbl > 0 {
+			drblblacklisted = drblCheckHostname(Q.Qname)
+			if Config.LogLevel > 0 {
+				log.Println("DrblBlistCheck enabled and checked =>", Q.Qname, "The result is =>", drblblacklisted)
+			}
+		} else {
+			if Config.LogLevel > 0 {
+				log.Println("DrblBlistCheck is disabled for =>", Q.Qname, "The result is =>", drblblacklisted)
+			}
+		}
+
+		if grimdActive && (blacklisted || drblblacklisted) {
 			m := new(dns.Msg)
 			m.SetReply(req)
 

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"os/signal"
 	"runtime"
 	"time"
+	"github.com/elico/drbl-peer"
 )
 
 var (
@@ -21,6 +22,7 @@ var (
 
 	// QuestionCache contains all queries to the dns server
 	QuestionCache = &MemoryQuestionCache{Backend: make([]QuestionCacheEntry, 0), Maxcount: 1000}
+	drblPeers *drblpeer.DrblPeers
 )
 
 func main() {
@@ -37,6 +39,15 @@ func main() {
 		log.Fatal(err)
 	}
 	defer logFile.Close()
+
+        if Config.UseDrbl > 0 {
+                drblPeers, _ = drblpeer.NewPeerListFromYamlFile(Config.DrblPeersFilename, Config.DrblBlockWeight, Config.DrblTimeout, (Config.LogLevel > 0))
+                if Config.DrblDebug > 0 {
+                        log.Println("Drbl Debug is ON")
+                        drblPeers.Debug = true
+                        log.Println("Drbl Debug is ON", drblPeers.Debug)
+                }
+        }
 
 	// delay updating the blocklists, cache until the server starts and can serve requests as the local resolver
 	timer := time.NewTimer(time.Second * 1)


### PR DESCRIPTION
As requested at:
https://github.com/looterz/grimd/issues/26

A PR that enables and allows the usage of the drbl-peer library to query live blacklists compared to loading hosts files over and over.
It's not the most optimized for low bandwidth connections but it's mainly tiny DNS and HTTP HEAD requests so it should be fine. 