### PR TITLE
Fixed race condition cause channel panics

### DIFF
--- a/server.go
+++ b/server.go
@@ -56,7 +56,10 @@ func (s *Server) start(ds *dns.Server) {
 // Stop stops the server
 func (s *Server) Stop() {
 	if s.handler != nil {
+		s.handler.muActive.Lock()
+		s.handler.active = false
 		close(s.handler.requestChannel)
+		s.handler.muActive.Unlock()
 	}
 	if s.udpServer != nil {
 		s.udpServer.Shutdown()


### PR DESCRIPTION
As explain in https://github.com/looterz/grimd/issues/62

There is a race condition between Stop method for Server and DoUDP and DoTCP for Handler.

When the call for reloadBlockCache happen and calls the Stop method for Server, there is a small window of time where the channel is closed, however the Handler is still active