### PR TITLE
added custom dns records

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ whitelist = [
 	"www.getsentry.com"
 ]
 
+# manual custom dns entries
+customdnsrecords = []
+
 # When this string is queried, toggle grimd on and off
 togglename = ""
 

--- a/config.go
+++ b/config.go
@@ -16,7 +16,7 @@ import (
 var BuildVersion = "1.0.7"
 
 // ConfigVersion returns the version of grimd, this should be incremented every time the config changes so grimd presents a warning
-var ConfigVersion = "1.0.7"
+var ConfigVersion = "1.0.8"
 
 // Config holds the configuration parameters
 type Config struct {
@@ -38,6 +38,7 @@ type Config struct {
 	TTL               uint32
 	Blocklist         []string
 	Whitelist         []string
+	CustomDNSRecords  []string
 	ToggleName        string
 	ReactivationDelay uint
 	APIDebug          bool
@@ -129,6 +130,9 @@ whitelist = [
 	"getsentry.com",
 	"www.getsentry.com"
 ]
+
+# manual custom dns entries
+customdnsrecords = []
 
 # When this string is queried, toggle grimd on and off
 togglename = ""

--- a/records.go
+++ b/records.go
@@ -1,0 +1,29 @@
+package main
+
+import "github.com/miekg/dns"
+
+type CustomDNSRecord struct {
+	handler *DNSHandler
+	answer  dns.RR
+}
+
+func NewCustomDNSRecord(handler *DNSHandler, recordText string) (*CustomDNSRecord, error) {
+	answer, answerErr := dns.NewRR(recordText)
+	if answerErr != nil {
+		return nil, answerErr
+	}
+
+	return &CustomDNSRecord{
+		handler: handler,
+		answer:  answer,
+	}, nil
+}
+
+func (c *CustomDNSRecord) serve(writer dns.ResponseWriter, req *dns.Msg) {
+	m := new(dns.Msg)
+	m.SetReply(req)
+
+	m.Answer = append(m.Answer, c.answer)
+
+	c.handler.WriteReplyMsg(writer, m)
+}

--- a/server.go
+++ b/server.go
@@ -31,10 +31,16 @@ func (s *Server) Run(config *Config,
 	for _, recordText := range config.CustomDNSRecords {
 		customRecord, customRecordErr := NewCustomDNSRecord(s.handler, recordText)
 		if customRecordErr == nil {
-			tcpHandler.HandleFunc(customRecord.answer.Header().Name, customRecord.serve)
-			udpHandler.HandleFunc(customRecord.answer.Header().Name, customRecord.serve)
+			name := customRecord.answer.Header().Name
+
+			if len(name) > 0 {
+				tcpHandler.HandleFunc(name, customRecord.serve)
+				udpHandler.HandleFunc(name, customRecord.serve)
+			} else {
+				logger.Errorf("Cannot parse custom record: invalid dns")
+			}
 		} else {
-			logger.Errorf("Cannot parse custom record %s", customRecordErr)
+			logger.Errorf("Cannot parse custom record: %s", customRecordErr)
 		}
 	}
 


### PR DESCRIPTION
Added the ability to add custom dns records. 

```
Example:
# manual custom dns entries
customdnsrecords = [
    "example.com	3600	IN	A	0.0.0.0"
]
```

https://github.com/looterz/grimd/issues/63
https://github.com/looterz/grimd/issues/64