### PR TITLE
Fix reload lockup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .vscode
 *.test
 pprof/
+grimd
+*.swp

--- a/api.go
+++ b/api.go
@@ -138,7 +138,10 @@ func StartAPIServer(config *Config,
 
 	router.POST("/blocklist/update", func(c *gin.Context) {
 		c.AbortWithStatus(http.StatusOK)
-		reloadChan <- true
+		// Send reload trigger to chan in background goroutine so does not hang
+		go func(reloadChan chan bool) {
+			reloadChan <- true
+		}(reloadChan)
 	})
 
 	listener, err := net.Listen("tcp", config.API)

--- a/main.go
+++ b/main.go
@@ -29,11 +29,14 @@ func reloadBlockCache(config *Config,
 	apiServer *http.Server,
 	server *Server,
 	reloadChan chan bool) (*MemoryBlockCache, *http.Server, error) {
+
 	logger.Debug("Reloading the blockcache")
 	blockCache = PerformUpdate(config, true)
 	server.Stop()
 	if apiServer != nil {
-		apiServer.Shutdown(context.Background())
+		if err := apiServer.Shutdown(context.Background()); err != nil {
+			logger.Debugf("error shutting down api server: %v", err)
+		}
 	}
 	server.Run(config, blockCache, questionCache)
 	apiServer, err := StartAPIServer(config, reloadChan, blockCache, questionCache)


### PR DESCRIPTION
If multiple api requests to /blocklist/update were received the api server shutdown would hang waiting for subsequent requests to complete but they were blocked waiting for the reloadChan to   be read.