### PR TITLE
add regexp support

### DIFF
--- a/api.go
+++ b/api.go
@@ -27,7 +27,11 @@ func StartAPIServer(config *Config,
 	router.Use(cors.Default())
 
 	router.GET("/blockcache", func(c *gin.Context) {
-		c.IndentedJSON(http.StatusOK, gin.H{"length": blockCache.Length(), "items": blockCache.Backend})
+		special := make([]string, 0, len(blockCache.Special))
+		for k := range blockCache.Special {
+			special = append(special, k)
+		}
+		c.IndentedJSON(http.StatusOK, gin.H{"length": blockCache.Length(), "items": blockCache.Backend, "special": special})
 	})
 
 	router.GET("/blockcache/exists/:key", func(c *gin.Context) {

--- a/updater.go
+++ b/updater.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 )
@@ -155,7 +156,7 @@ func parseHostFile(fileName string, blockCache *MemoryBlockCache) error {
 // PerformUpdate updates the block cache by building a new one and swapping
 // it for the old cache.
 func PerformUpdate(config *Config, forceUpdate bool) *MemoryBlockCache {
-	newBlockCache := &MemoryBlockCache{Backend: make(map[string]bool)}
+	newBlockCache := &MemoryBlockCache{Backend: make(map[string]bool), Special: make(map[string]*regexp.Regexp)}
 	if _, err := os.Stat("lists"); os.IsNotExist(err) || forceUpdate {
 		if err := update(newBlockCache, config.Whitelist, config.Blocklist, config.Sources); err != nil {
 			logger.Fatal(err)


### PR DESCRIPTION
* Hostnames starting with ~ will be treated as regular expressions - queries will be lowercased before matching.
* Globs remain supported.
* `/blockcache/*` API calls can now list/remove regular expression and glob hosts
* MemoryBlockCache.Special reworked as a `map` of `*regexp.Regexp`s, with `nil` for simple globs

Example entry for blocking [instart logic g00](https://github.com/gorhill/uBO-Extra/issues/119) hosts:

`~^[0-9a-z-]+[.]g00[.]`

Having a lot of glob/regexp entries blocked may be slow, try to use sparingly.

Fixes #35 