### PR TITLE
update list urls and remove dead ones

### DIFF
--- a/config.go
+++ b/config.go
@@ -55,14 +55,12 @@ version = "%s"
 
 # list of sources to pull blocklists from, stores them in ./sources
 sources = [
-"http://mirror1.malwaredomains.com/files/justdomains",
+"https://mirror1.malwaredomains.com/files/justdomains",
 "https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts",
-"http://sysctl.org/cameleon/hosts",
-"https://zeustracker.abuse.ch/blocklist.php?download=domainblocklist",
+"https://sysctl.org/cameleon/hosts",
 "https://s3.amazonaws.com/lists.disconnect.me/simple_tracking.txt",
 "https://s3.amazonaws.com/lists.disconnect.me/simple_ad.txt",
-"http://hosts-file.net/ad_servers.txt",
-"https://raw.githubusercontent.com/quidsup/notrack/master/trackers.txt"
+"https://gitlab.com/quidsup/notrack-blocklists/raw/master/notrack-blocklist.txt"
 ]
 
 # list of locations to recursively read blocklists from (warning, every file found is assumed to be a hosts-file or domain list)


### PR DESCRIPTION
Updated sources in default config.

* zeustracker is dead
* malwaredomains supports https
* sysctl.org supports https
* hosts-file.net is now owned by malwarebytes and no longer has a hosts file
* notrack is now on gitlab