### PR TITLE
fix certs in container to allow list download, and show use in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
+FROM alpine:3.15.0 as certs
+RUN apk --update add ca-certificates
+
 FROM scratch
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY grimd /usr/bin/grimd
 EXPOSE 53:53/udp
 EXPOSE 53:53/tcp

--- a/README.md
+++ b/README.md
@@ -117,6 +117,15 @@ Requires golang 1.7 or higher, you build grimd like any other golang application
 env GOOS=linux GOARCH=amd64 go build -v github.com/looterz/grimd
 ```
 
+# Run container and test
+
+mkdir sources
+docker build -t grimd:latest . && \
+docker run -v $PWD/sources:/sources --rm -it -P --name grimd-test grimd:latest --config /sources/grimd.toml --update
+
+# For Mac docker, must set 'api = "0.0.0.0:8080"' instead of 'api = "127.0.0.1:8080"' to get networking correct
+# curl -H "Accept: application/json"   http://127.0.0.1:55006/application/active
+
 # Web API
 A restful json api is exposed by default on the local interface, allowing you to build web applications that visualize requests, blocks and the cache. [reaper](https://github.com/looterz/reaper) is the default grimd web frontend.
 


### PR DESCRIPTION
Stumbled into this repo and found I couldn't use the docker container. Running the existing public image left me with x509 cert errors when downloading the block lists. This change adds ca certs to fix that problem and adds a brief comment for how to run it in container. Haven't actually dug into running wit it yet, but this gets me to a place I can play.