### PR TITLE
fix: allow the project to complete the build in the docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,20 @@
 FROM alpine:3.15.0 as certs
 RUN apk --update add ca-certificates
 
+FROM golang:1.18.0-alpine3.15 AS builder
+RUN apk add git bash gcc musl-dev upx
+WORKDIR /app
+COPY . .
+RUN go mod tidy
+RUN go test -v ./...
+ENV CGO_ENABLED=0
+RUN GOARCH=amd64 go build -ldflags "-w -s" -v ./...
+RUN upx -9 -o grimd.minify grimd && mv grimd.minify grimd
+
 FROM scratch
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY grimd /usr/bin/grimd
-EXPOSE 53/udp
-EXPOSE 53/tcp
-EXPOSE 8080/tcp
+COPY --from=builder /app/grimd /usr/bin/grimd
+EXPOSE 53:53/udp
+EXPOSE 53:53/tcp
+EXPOSE 8080
 ENTRYPOINT ["/usr/bin/grimd"]


### PR DESCRIPTION
Explain why two alpine-based mirrors are used without merging:

Since the functions of the two mirrors are different, there is no need for us to merge them in order to minimize the size of the build process. In the future, there may even be a situation where we only upgrade to a certain image.

So, keeping two mirrors may seem reasonable at the moment.