### PR TITLE
strict host entry parsing

### DIFF
--- a/updater.go
+++ b/updater.go
@@ -153,7 +153,12 @@ func parseHostFile(fileName string, blockCache *MemoryBlockCache) error {
 			fields := strings.Fields(line)
 
 			if len(fields) > 1 {
-				line = fields[1]
+				// verify this is something that ought to be blocked
+				if fields[0] == "127.0.0.1" || fields[0] == "0.0.0.0" {
+					line = fields[1]
+				} else {
+					continue
+				}
 			} else {
 				line = fields[0]
 			}


### PR DESCRIPTION
This patch requires that hosts file entries have either 0.0.0.0 or 127.0.0.1 as the IP address in order to be blocked.

I can't remember why I implemented this, and it might make sense to put this behind a config option.